### PR TITLE
Feature/security

### DIFF
--- a/src/main/java/com/project/marketplace/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/project/marketplace/delivery/controller/DeliveryController.java
@@ -26,9 +26,8 @@ public class DeliveryController {
     private final UserService userService;
 
     @GetMapping
-    public ResponseEntity<List<DeliveryUpdateResponseDto>> getAllDeliveries(Authentication authentication) {
-        // 전체 배송 목록은 관리자만 조회
-        getAdminUser(authentication);
+    public ResponseEntity<List<DeliveryUpdateResponseDto>> getAllDeliveries() {
+        // 전체 배송 목록 관리자 제한은 SecurityConfig에서 처리함
         return ResponseEntity.ok(deliveryService.findAllDeliveryWithDto());
     }
 
@@ -45,16 +44,15 @@ public class DeliveryController {
             @PathVariable Long id,
             Authentication authentication,
             @RequestBody DeliveryUpdateRequestDto requestDto) {
-        // 배송 수정은 관리자 또는 해당 주문 상품의 판매자만 가능하도록 제한함
-        User user = getDeliveryManager(authentication);
+        // 배송 수정 role 제한은 SecurityConfig에서 처리하고 실제 담당 판매자 여부는 서비스에서 검증함
+        User user = getAuthenticatedUser(authentication, "로그인 후 이용할 수 있습니다.");
         boolean admin = user.getRole() == UserRole.ADMIN;
         return ResponseEntity.ok(deliveryService.updateDeliveryWithDto(id, user.getId(), admin, requestDto));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteDelivery(@PathVariable Long id, Authentication authentication) {
-        // 배송 삭제는 관리자만 허용함
-        getAdminUser(authentication);
+    public ResponseEntity<Void> deleteDelivery(@PathVariable Long id) {
+        // 배송 삭제 관리자 제한은 SecurityConfig에서 처리함
         deliveryService.deleteDelivery(id);
         return ResponseEntity.noContent().build();
     }
@@ -65,21 +63,4 @@ public class DeliveryController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, unauthorizedMessage));
     }
 
-    // 배송 관리 API는 관리자만 접근하도록 공통 권한 검사를 사용함
-    private User getAdminUser(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication, "로그인 후 이용할 수 있습니다.");
-        if (user.getRole() != UserRole.ADMIN) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자만 이용할 수 있습니다.");
-        }
-        return user;
-    }
-
-    // 배송 수정 권한은 관리자와 판매자에게만 열고 실제 담당 판매자 여부는 서비스에서 검증함
-    private User getDeliveryManager(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication, "로그인 후 이용할 수 있습니다.");
-        if (user.getRole() != UserRole.ADMIN && user.getRole() != UserRole.SELLER) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "배송 수정 권한이 없습니다.");
-        }
-        return user;
-    }
 }

--- a/src/main/java/com/project/marketplace/order/controller/OrderController.java
+++ b/src/main/java/com/project/marketplace/order/controller/OrderController.java
@@ -6,7 +6,6 @@ import com.project.marketplace.order.dto.OrderUpdateRequestDto;
 import com.project.marketplace.order.entity.OrderStatus;
 import com.project.marketplace.order.service.OrderService;
 import com.project.marketplace.user.entity.User;
-import com.project.marketplace.user.entity.UserRole;
 import com.project.marketplace.user.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -79,9 +78,8 @@ public class OrderController {
      * 모든 주문을 조회합니다.
      */
     @GetMapping // /api/orders
-    public ResponseEntity<List<OrderResponseDto>> getAllOrders(Authentication authentication) {
-        // 전체 주문 목록은 모든 사용자 주문이 노출되므로 관리자만 조회하도록 제한함
-        getAdminUser(authentication);
+    public ResponseEntity<List<OrderResponseDto>> getAllOrders() {
+        // 전체 주문 목록 관리자 제한은 SecurityConfig에서 처리함
         List<OrderResponseDto> orders = orderService.getAllOrders();
         return ResponseEntity.ok(orders);
     }
@@ -92,11 +90,9 @@ public class OrderController {
     @PatchMapping("/{orderId}/status") // /api/orders/{orderId}/status
     public ResponseEntity<Void> updateOrderStatus(
             @PathVariable Long orderId,
-            Authentication authentication,
             @RequestBody Map<String, String> statusUpdate) {
 
-        // 주문 상태 변경은 운영자 권한 작업이므로 관리자만 허용함
-        getAdminUser(authentication);
+        // 주문 상태 변경 관리자 제한은 SecurityConfig에서 처리함
         String orderStatus = statusUpdate.get("orderStatus");
 
         if (orderStatus == null) {
@@ -144,12 +140,4 @@ public class OrderController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, unauthorizedMessage));
     }
 
-    // 관리자 전용 주문 API에서 같은 권한 검사를 반복하지 않도록 분리함
-    private User getAdminUser(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication, "로그인 후 이용할 수 있습니다.");
-        if (user.getRole() != UserRole.ADMIN) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자만 이용할 수 있습니다.");
-        }
-        return user;
-    }
 }

--- a/src/main/java/com/project/marketplace/product/controller/ProductController.java
+++ b/src/main/java/com/project/marketplace/product/controller/ProductController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.Map;
 
@@ -96,12 +97,18 @@ public class ProductController {
     @PutMapping("/{productId}")
     public ResponseEntity<Void> updateProduct(
             @PathVariable Long productId,
-            @RequestBody ProductDto productDto) {
+            @RequestBody ProductDto productDto,
+            Authentication authentication) {
         // 컨트롤러의 사전 조회를 제거하고 경로 ID와 본문 ID 일치만 검증해 서비스 단 조회로 중복 쿼리를 줄였다.
         if (!productId.equals(productDto.getProductId())) {
             return ResponseEntity.badRequest().build();
         }
-        productService.updateProduct(productDto);
+        // 상품 수정은 현재 로그인 사용자를 서비스에 넘겨 판매자 본인 여부를 검증하게 함
+        Long currentUserId = resolveCurrentUserId(authentication);
+        if (currentUserId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        productService.updateProduct(productDto, currentUserId);
 
         return ResponseEntity.ok().build();
     }
@@ -127,7 +134,8 @@ public class ProductController {
     @PatchMapping("/{productId}/quantity")
     public ResponseEntity<Void> updateProductQuantity(
             @PathVariable Long productId,
-            @RequestBody Map<String, Integer> request) {
+            @RequestBody Map<String, Integer> request,
+            Authentication authentication) {
 
         try {
             Integer quantity = request.get("quantity");
@@ -135,8 +143,16 @@ public class ProductController {
                 return ResponseEntity.badRequest().build();
             }
 
-            productService.updateProductQuantity(productId, quantity);
+            // 재고 변경도 상품 수정 권한과 같은 판매자 본인 검사를 거치게 함
+            Long currentUserId = resolveCurrentUserId(authentication);
+            if (currentUserId == null) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+            productService.updateProductQuantity(productId, quantity, currentUserId);
             return ResponseEntity.ok().build();
+        } catch (ResponseStatusException e) {
+            // 권한/인증 예외는 상태 코드가 유지되도록 그대로 전달함
+            throw e;
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().build();
         }

--- a/src/main/java/com/project/marketplace/product/service/ProductService.java
+++ b/src/main/java/com/project/marketplace/product/service/ProductService.java
@@ -87,9 +87,14 @@ public class ProductService {
     }
 
     @Transactional
-    public void updateProduct(ProductDto dto) {
+    public void updateProduct(ProductDto dto, Long requesterUserId) {
         Product product = productRepository.findById(dto.getProductId())
-                .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "상품을 찾을 수 없습니다."));
+        User requester = userRepository.findById(requesterUserId)
+                .orElseThrow(() -> new ResponseStatusException(UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
+
+        // 상품 수정은 관리자 또는 상품 판매자 본인만 가능하도록 제한함
+        validateProductManager(product, requester, "본인 상품만 수정할 수 있습니다.");
 
         product.setName(dto.getProductName());
         product.setCategory(dto.getCategory());
@@ -97,13 +102,7 @@ public class ProductService {
         product.setQuantity(dto.getQuantity());
         product.setDescription(dto.getMainImage());
         product.setIsSoldOut(dto.getQuantity() <= 0);
-        // 수정 요청에 sellerId가 포함되면 판매자 연관관계도 함께 갱신할 수 있게 처리했다.
-        if (dto.getSellerId() != null) {
-            // 전달된 sellerId를 검증해 존재하는 사용자로만 판매자 변경이 되도록 했다.
-            User seller = userRepository.findById(dto.getSellerId())
-                    .orElseThrow(() -> new RuntimeException("판매자를 찾을 수 없습니다. ID: " + dto.getSellerId()));
-            product.setSeller(seller);
-        }
+        // 수정 요청의 sellerId는 상품 소유자 변경으로 악용될 수 있어 반영하지 않음
 
         productRepository.save(product);
     }
@@ -115,14 +114,22 @@ public class ProductService {
         User requester = userRepository.findById(requesterUserId)
                 .orElseThrow(() -> new ResponseStatusException(UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
 
-        // 관리자 또는 판매자 본인만 상품을 삭제할 수 있게 권한을 제한
-        boolean canDelete = requester.getRole() == UserRole.ADMIN
-                || (product.getSeller() != null && requesterUserId.equals(product.getSeller().getId()));
-        if (!canDelete) {
-            throw new ResponseStatusException(FORBIDDEN, "본인 상품만 삭제할 수 있습니다.");
-        }
+        // 상품 삭제도 수정과 같은 관리자 또는 판매자 본인 기준을 재사용함
+        validateProductManager(product, requester, "본인 상품만 삭제할 수 있습니다.");
 
         productRepository.delete(product);
+    }
+
+    @Transactional
+    public void updateProductQuantity(Long productId, Integer quantityChange, Long requesterUserId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "상품을 찾을 수 없습니다."));
+        User requester = userRepository.findById(requesterUserId)
+                .orElseThrow(() -> new ResponseStatusException(UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
+
+        // 재고 변경도 상품 수정 권한과 같은 관리자 또는 판매자 본인 기준을 적용함
+        validateProductManager(product, requester, "본인 상품만 수정할 수 있습니다.");
+        applyQuantityChange(product, quantityChange);
     }
 
     @Transactional
@@ -130,6 +137,12 @@ public class ProductService {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다. ID: " + productId));
 
+        // 구매 처리에서는 주문 흐름에서 검증하므로 재고 증감만 공통 처리함
+        applyQuantityChange(product, quantityChange);
+    }
+
+    private void applyQuantityChange(Product product, Integer quantityChange) {
+        // 재고 변경 계산을 한 곳으로 모아 판매자 수정과 구매 차감 흐름을 동일하게 처리함
         if (quantityChange < 0 && product.getQuantity() < -quantityChange) {
             throw new RuntimeException("상품 재고가 부족합니다.");
         }
@@ -137,6 +150,15 @@ public class ProductService {
         product.setQuantity(product.getQuantity() + quantityChange);
         product.setIsSoldOut(product.getQuantity() <= 0);
         productRepository.save(product);
+    }
+
+    private void validateProductManager(Product product, User requester, String forbiddenMessage) {
+        // 관리자이거나 상품 판매자 본인인지 확인해 다른 판매자 상품 변경을 막음
+        boolean canManage = requester.getRole() == UserRole.ADMIN
+                || (product.getSeller() != null && requester.getId().equals(product.getSeller().getId()));
+        if (!canManage) {
+            throw new ResponseStatusException(FORBIDDEN, forbiddenMessage);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/project/marketplace/security/SecurityConfig.java
+++ b/src/main/java/com/project/marketplace/security/SecurityConfig.java
@@ -42,11 +42,13 @@ public class SecurityConfig {
                         .requestMatchers(antMatcher("/admin/**")).hasRole("ADMIN")
                         .requestMatchers(antMatcher(HttpMethod.GET, "/api/user/list")).hasRole("ADMIN")
                         .requestMatchers(antMatcher(HttpMethod.GET, "/api/products"), antMatcher(HttpMethod.GET, "/api/products/**"), antMatcher(HttpMethod.GET, "/products/**")).permitAll()
-                        .requestMatchers(antMatcher("/seller/**"), antMatcher("/orders"), antMatcher("/api/carts/**"), antMatcher("/api/orders/**")).authenticated()
-                        .requestMatchers(antMatcher(HttpMethod.POST, "/api/products")).authenticated()
-                        .requestMatchers(antMatcher(HttpMethod.PUT, "/api/products/**")).authenticated()
-                        .requestMatchers(antMatcher(HttpMethod.PATCH, "/api/products/**")).authenticated()
-                        .requestMatchers(antMatcher(HttpMethod.DELETE, "/api/products/**")).authenticated()
+                        // 상품 관리 화면과 변경 API는 판매자와 관리자만 접근하도록 제한함
+                        .requestMatchers(antMatcher("/seller/**")).hasAnyRole("SELLER", "ADMIN")
+                        .requestMatchers(antMatcher(HttpMethod.POST, "/api/products")).hasAnyRole("SELLER", "ADMIN")
+                        .requestMatchers(antMatcher(HttpMethod.PUT, "/api/products/**")).hasAnyRole("SELLER", "ADMIN")
+                        .requestMatchers(antMatcher(HttpMethod.PATCH, "/api/products/**")).hasAnyRole("SELLER", "ADMIN")
+                        .requestMatchers(antMatcher(HttpMethod.DELETE, "/api/products/**")).hasAnyRole("SELLER", "ADMIN")
+                        .requestMatchers(antMatcher("/orders"), antMatcher("/api/carts/**"), antMatcher("/api/orders/**")).authenticated()
                         .requestMatchers(antMatcher("/api/user/admin/**")).hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/project/marketplace/security/SecurityConfig.java
+++ b/src/main/java/com/project/marketplace/security/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
                         // 관리자 화면과 사용자 목록 API는 관리자 권한으로 제한함
                         .requestMatchers(antMatcher("/admin/**")).hasRole("ADMIN")
                         .requestMatchers(antMatcher(HttpMethod.GET, "/api/user/list")).hasRole("ADMIN")
+                        // 내 상품 목록은 공개 상품 조회보다 먼저 제한해 판매자와 관리자만 접근하게 함
+                        .requestMatchers(antMatcher(HttpMethod.GET, "/api/products/mine")).hasAnyRole("SELLER", "ADMIN")
                         .requestMatchers(antMatcher(HttpMethod.GET, "/api/products"), antMatcher(HttpMethod.GET, "/api/products/**"), antMatcher(HttpMethod.GET, "/products/**")).permitAll()
                         // 상품 관리 화면과 변경 API는 판매자와 관리자만 접근하도록 제한함
                         .requestMatchers(antMatcher("/seller/**")).hasAnyRole("SELLER", "ADMIN")
@@ -48,6 +50,13 @@ public class SecurityConfig {
                         .requestMatchers(antMatcher(HttpMethod.PUT, "/api/products/**")).hasAnyRole("SELLER", "ADMIN")
                         .requestMatchers(antMatcher(HttpMethod.PATCH, "/api/products/**")).hasAnyRole("SELLER", "ADMIN")
                         .requestMatchers(antMatcher(HttpMethod.DELETE, "/api/products/**")).hasAnyRole("SELLER", "ADMIN")
+                        // 배송 관리 역할 정책을 SecurityConfig로 모아 컨트롤러의 중복 role 검사를 줄임
+                        .requestMatchers(antMatcher(HttpMethod.GET, "/api/delivery")).hasRole("ADMIN")
+                        .requestMatchers(antMatcher(HttpMethod.PUT, "/api/delivery/**")).hasAnyRole("SELLER", "ADMIN")
+                        .requestMatchers(antMatcher(HttpMethod.DELETE, "/api/delivery/**")).hasRole("ADMIN")
+                        // 주문 운영 역할 정책을 SecurityConfig로 모아 컨트롤러의 중복 role 검사를 줄임
+                        .requestMatchers(antMatcher(HttpMethod.GET, "/api/orders")).hasRole("ADMIN")
+                        .requestMatchers(antMatcher(HttpMethod.PATCH, "/api/orders/*/status")).hasRole("ADMIN")
                         .requestMatchers(antMatcher("/orders"), antMatcher("/api/carts/**"), antMatcher("/api/orders/**")).authenticated()
                         .requestMatchers(antMatcher("/api/user/admin/**")).hasRole("ADMIN")
                         .anyRequest().authenticated())

--- a/src/main/java/com/project/marketplace/user/controller/OAuthController.java
+++ b/src/main/java/com/project/marketplace/user/controller/OAuthController.java
@@ -99,9 +99,7 @@ public class OAuthController {//일단 만들어보자구
     // 관리자 사용자 관리 화면은 역할 변경/삭제 API를 다루므로 관리자만 진입하게 함
     @GetMapping("/admin/users")
     public String adminUsers(Model model, Authentication authentication) {
-        if (!isAdmin(authentication)) {
-            return "redirect:/";
-        }
+        // 관리자 화면 접근 제한은 SecurityConfig에서 처리함
         addAuthInfoToModel(model, authentication);
         return "admin-users";
     }
@@ -109,9 +107,7 @@ public class OAuthController {//일단 만들어보자구
     // 관리자 배송 관리 화면은 전체 배송 목록과 삭제 API를 다루므로 관리자만 진입하게 함
     @GetMapping("/admin/delivery")
     public String adminDelivery(Model model, Authentication authentication) {
-        if (!isAdmin(authentication)) {
-            return "redirect:/";
-        }
+        // 관리자 화면 접근 제한은 SecurityConfig에서 처리함
         addAuthInfoToModel(model, authentication);
         return "admin-delivery";
     }
@@ -119,15 +115,7 @@ public class OAuthController {//일단 만들어보자구
     // 상품 등록 MVP 화면 진입 경로를 추가
     @GetMapping("/seller/products/new")
     public String productForm(Model model, Authentication authentication) {
-        boolean isLoggedIn = authentication != null
-                && authentication.isAuthenticated()
-                && !(authentication instanceof AnonymousAuthenticationToken)
-                && !"anonymousUser".equals(authentication.getPrincipal());
-
-        if (!isLoggedIn) {
-            return "redirect:/login";
-        }
-
+        // 판매자 화면 접근 제한은 SecurityConfig에서 처리함
         addAuthInfoToModel(model, authentication);
         return "product-form";
     }
@@ -228,13 +216,6 @@ public class OAuthController {//일단 만들어보자구
     // 화면 라우트 권한 판단도 공통 인증 사용자 해석 결과를 재사용함
     private Optional<User> resolveCurrentUser(Authentication authentication) {
         return userService.getAuthenticatedUser(authentication);
-    }
-
-    // 관리자 전용 템플릿 진입 여부를 DB 사용자 역할 기준으로 판단함
-    private boolean isAdmin(Authentication authentication) {
-        return resolveCurrentUser(authentication)
-                .map(user -> "ADMIN".equals(user.getRole().name()))
-                .orElse(false);
     }
 
     private String resolveProvider(Authentication authentication, Map<String, Object> attributes) {


### PR DESCRIPTION
- 상품 관리 화면과 상품 변경 API를 판매자/관리자만 접근 가능하게 제한
  - 내 상품 목록 API를 공개 상품 조회보다 먼저 권한 제한                                           
  - 상품 수정과 재고 변경 시 판매자 본인 또는 관리자만 허용                                        
  - 상품 수정 요청의 sellerId 반영 제거                                                            
  - 배송/주문/화면 컨트롤러의 중복 role 검사 제거                                                  
  - 배송/주문 운영 권한을 SecurityConfig에서 관리                                                  
  - 소유권 검사는 기존 서비스 로직에 유지          