### PR TITLE
Redis 세션저장소 적용 및 테스트코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// Blue-Green 전환 후에도 같은 로그인 세션을 공유하도록 HTTP 세션 저장소를 Redis로 확장함
+	implementation 'org.springframework.session:spring-session-data-redis'
+	// Spring Session Redis가 Redis 연결 팩토리와 클라이언트를 자동 구성할 수 있게 추가함
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	// API 명세와 Swagger UI를 자동 생성해 현재 구현된 REST API를 문서화함
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/project/marketplace/config/RedisSessionConfig.java
+++ b/src/main/java/com/project/marketplace/config/RedisSessionConfig.java
@@ -1,0 +1,28 @@
+package com.project.marketplace.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.session.MapSession;
+import org.springframework.session.MapSessionRepository;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+public class RedisSessionConfig {
+
+    @Bean
+    public ConfigureRedisAction configureRedisAction() {
+        // 운영 Redis에서 CONFIG 명령이 막혀 있어도 세션 저장소 초기화가 실패하지 않게 함
+        return ConfigureRedisAction.NO_OP;
+    }
+
+    @Bean
+    @Profile("test")
+    public SessionRepository<MapSession> sessionRepository() {
+        // 테스트에서는 외부 Redis 없이 메모리 세션으로 OAuth 흐름을 검증함
+        return new MapSessionRepository(new ConcurrentHashMap<>());
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,30 @@ server:
         secure: true
 
 spring:
+  session:
+    # 운영 Blue-Green 배포에서 8080/8081이 같은 로그인 세션을 보도록 Redis 저장소를 사용함
+    store-type: redis
+    redis:
+      # Redis 안에서 이 서비스 세션 key를 구분해 다른 데이터와 섞이지 않게 함
+      namespace: handmade:session
+      # 요청이 끝날 때 변경된 세션만 저장해 Redis 쓰기 부담을 줄임
+      flush-mode: on-save
+      # 변경된 세션 속성만 저장해 OAuth2/일반 로그인 세션 갱신 범위를 줄임
+      save-mode: on-set-attribute
+
+  data:
+    redis:
+      # EC2 Redis 주소를 환경변수로 바꿀 수 있게 하되 기본은 같은 서버 localhost로 둠
+      host: ${REDIS_HOST:127.0.0.1}
+      # Redis 기본 포트를 사용하고 운영에서 필요하면 환경변수로 변경함
+      port: ${REDIS_PORT:6379}
+      # Redis DB 번호를 환경변수로 분리해 세션 저장 공간을 나눌 수 있게 함
+      database: ${REDIS_DATABASE:0}
+      # Redis 암호가 없는 로컬/EC2 구성을 기본값으로 두고 필요 시 환경변수로 주입함
+      password: ${REDIS_PASSWORD:}
+      # Redis 장애 시 요청이 오래 묶이지 않도록 연결 대기 시간을 제한함
+      timeout: ${REDIS_TIMEOUT:3s}
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/test/java/com/project/marketplace/config/RedisSessionConfigTest.java
+++ b/src/test/java/com/project/marketplace/config/RedisSessionConfigTest.java
@@ -1,0 +1,67 @@
+package com.project.marketplace.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.session.MapSessionRepository;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// Redis 의존성이 있어도 테스트 프로필에서는 외부 Redis 없이 컨텍스트가 떠야 함
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class RedisSessionConfigTest {
+
+    @Autowired
+    private ConfigureRedisAction configureRedisAction;
+
+    // 테스트 요청이 Redis가 아니라 메모리 세션 저장소를 쓰는지 직접 검증함
+    @Autowired
+    private SessionRepository<?> sessionRepository;
+
+    // Redis 세션 설정을 붙여도 OAuth 클라이언트 등록은 테스트 프로필에서 같이 검증되게 함
+    @Autowired
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    // 네이버 OAuth2 인증 시작 URL이 실제 provider redirect까지 이어지는지 확인함
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testProfileUsesInMemorySessionRepository() {
+        assertThat(sessionRepository).isInstanceOf(MapSessionRepository.class);
+        assertThat(configureRedisAction).isEqualTo(ConfigureRedisAction.NO_OP);
+    }
+
+    @Test
+    void oauthClientRegistrationsAreLoadedForLoginFlow() {
+        // 네이버/구글 로그인 설정이 테스트 프로필에서도 누락되지 않았는지 확인함
+        ClientRegistration naver = clientRegistrationRepository.findByRegistrationId("naver");
+        ClientRegistration google = clientRegistrationRepository.findByRegistrationId("google");
+
+        assertThat(naver).isNotNull();
+        assertThat(google).isNotNull();
+        assertThat(naver.getScopes()).contains("name", "email");
+        assertThat(google.getScopes()).contains("openid", "profile", "email");
+    }
+
+    @Test
+    void naverOAuthAuthorizationEndpointRedirectsToProvider() throws Exception {
+        // 실제 네이버 인증 성공 대신 우리 서버의 OAuth2 진입점이 정상 redirect되는지 검증함
+        mockMvc.perform(get("/oauth2/authorization/naver"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location", containsString("https://nid.naver.com/oauth2.0/authorize")));
+    }
+}


### PR DESCRIPTION
 변경 내용                                                                                                                                                                 
  - Spring Session Redis 의존성 추가                                              
  - 기존 인메모리 세션은 Blue-Green 배포 시 active 서버가 바뀌면 로그인 세션이 끊길 수 있기 때문에 운영 환경에서  HTTP 세션을 
    Redis   에 저장하도록 설정                                                                                                                          
  - 로컬 환경도 Docker Redis 기준으로 세션 설정 정리                                                                                                                           
  - 테스트 환경은 외부 Redis 없이 메모리 세션을 사용하도록 분리                                                                                                                
  - Redis 세션 설정과 OAuth 로그인 진입 흐름 테스트 코드 추가                                                                                                                       
                                                                                                                                                                               
                                                                                                                                                                   
     