### PR TITLE
feat : S3 스토리지 및 CloudFront 구축 및 연동 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation 'org.springframework.session:spring-session-data-redis'
 	// Spring Session Redis가 Redis 연결 팩토리와 클라이언트를 자동 구성할 수 있게 추가함
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// S3 이미지 업로드를 AWS SDK v2 클라이언트로 처리하기 위해 SDK BOM과 S3 모듈을 추가함
+	implementation platform('software.amazon.awssdk:bom:2.29.52')
+	implementation 'software.amazon.awssdk:s3'
 	// API 명세와 Swagger UI를 자동 생성해 현재 구현된 REST API를 문서화함
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
 	compileOnly 'org.projectlombok:lombok'

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -8,8 +8,10 @@ import { getPopularProducts, getProducts } from "../products/productApi";
 import { formatPrice, isImageUrl } from "../products/productDisplay";
 import "./HomePage.css";
 
-// CloudFront 기본 주소가 없으면 빈 값으로 두어 기존 그라데이션 배너를 유지함
-const HOME_IMAGE_BASE_URL = normalizeHomeImageBaseUrl(import.meta.env.VITE_CLOUDFRONT_IMAGE_BASE_URL);
+// 백엔드 설정명과 맞춘 CloudFront 주소를 우선 사용하고 기존 이미지 전용 env는 fallback으로 유지함
+const HOME_IMAGE_BASE_URL = normalizeHomeImageBaseUrl(
+    import.meta.env.VITE_CLOUDFRONT_BASE_URL || import.meta.env.VITE_CLOUDFRONT_IMAGE_BASE_URL
+);
 
 // 홈 빠른 카테고리는 실제 상품 목록 필터와 같은 값만 노출함
 const CATEGORY_LINKS = [

--- a/frontend/src/pages/products/productDisplay.js
+++ b/frontend/src/pages/products/productDisplay.js
@@ -8,8 +8,13 @@ export function formatPrice(value) {
     return `${Number(value ?? 0).toLocaleString("ko-KR")}원`;
 }
 
-// 현재 DTO의 mainImage 값이 설명 문자열인 경우 상세 설명으로 사용함
+// 상품 설명은 분리된 description 필드를 우선 사용하고 기존 데이터만 mainImage 설명값으로 보완함
 export function getProductDescription(product) {
+    const description = product?.description?.trim();
+    if (description) {
+        return description;
+    }
+
     const mainImage = product?.mainImage?.trim();
 
     if (!mainImage || isImageUrl(mainImage)) {

--- a/src/main/java/com/project/marketplace/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/marketplace/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.project.marketplace.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import com.project.marketplace.storage.ImageStorageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -66,6 +67,23 @@ public class GlobalExceptionHandler {
                         HttpStatus.BAD_REQUEST.value(),
                         HttpStatus.BAD_REQUEST.getReasonPhrase(),
                         message,
+                        request.getRequestURI()
+                ));
+    }
+
+    // S3 저장소 설정이나 통신 실패는 사용자 입력 오류와 구분해 저장소 상태 코드로 응답함
+    @ExceptionHandler(ImageStorageException.class)
+    public ResponseEntity<ErrorResponse> handleImageStorageException(
+            ImageStorageException exception,
+            HttpServletRequest request
+    ) {
+        HttpStatus status = exception.getStatus();
+
+        return ResponseEntity.status(status)
+                .body(ErrorResponse.of(
+                        status.value(),
+                        status.getReasonPhrase(),
+                        resolveMessage(exception.getMessage(), "이미지 저장소 처리 중 오류가 발생했습니다."),
                         request.getRequestURI()
                 ));
     }

--- a/src/main/java/com/project/marketplace/config/S3StorageConfig.java
+++ b/src/main/java/com/project/marketplace/config/S3StorageConfig.java
@@ -1,0 +1,21 @@
+package com.project.marketplace.config;
+
+import com.project.marketplace.storage.StorageProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@EnableConfigurationProperties(StorageProperties.class)
+public class S3StorageConfig {
+
+    @Bean
+    public S3Client s3Client(StorageProperties storageProperties) {
+        // S3 클라이언트 리전을 운영 환경변수와 같은 app.storage.s3.region 기준으로 생성함
+        return S3Client.builder()
+                .region(Region.of(storageProperties.getS3().getRegion()))
+                .build();
+    }
+}

--- a/src/main/java/com/project/marketplace/product/controller/ProductController.java
+++ b/src/main/java/com/project/marketplace/product/controller/ProductController.java
@@ -7,10 +7,12 @@ import com.project.marketplace.user.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Map;
 
@@ -91,6 +93,21 @@ public class ProductController {
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("productId", productId));
     }
 
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, Long>> createProductWithImage(
+            @RequestPart("product") ProductDto productDto,
+            @RequestPart(value = "mainImageFile", required = false) MultipartFile mainImageFile,
+            Authentication authentication) {
+        // multipart 등록 요청은 이미지 파일을 S3에 저장한 뒤 상품 mainImage URL로 함께 저장함
+        Long currentUserId = resolveCurrentUserId(authentication);
+        if (currentUserId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        productDto.setSellerId(currentUserId);
+        Long productId = productService.createProduct(productDto, mainImageFile);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("productId", productId));
+    }
+
     /**
      * 상품 정보를 수정합니다.
      */
@@ -109,6 +126,25 @@ public class ProductController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         productService.updateProduct(productDto, currentUserId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping(path = "/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> updateProductWithImage(
+            @PathVariable Long productId,
+            @RequestPart("product") ProductDto productDto,
+            @RequestPart(value = "mainImageFile", required = false) MultipartFile mainImageFile,
+            Authentication authentication) {
+        // multipart 수정 요청도 JSON 수정과 같은 ID 검증과 권한 검증 흐름을 사용함
+        if (!productId.equals(productDto.getProductId())) {
+            return ResponseEntity.badRequest().build();
+        }
+        Long currentUserId = resolveCurrentUserId(authentication);
+        if (currentUserId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        productService.updateProduct(productDto, currentUserId, mainImageFile);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/project/marketplace/product/dto/ProductDto.java
+++ b/src/main/java/com/project/marketplace/product/dto/ProductDto.java
@@ -18,6 +18,8 @@ public class ProductDto {
     private Boolean isSoldOut;     // 품절 여부
     private Integer quantity;      // 재고
     private Integer salesCount;    // 판매 수량
+    // 상품 상세 설명을 이미지 경로와 분리해 텍스트 설명으로 내려줌
+    private String description;     // 상품 설명
     private String mainImage;      // 메인 이미지 경로
     // 상품 응답에서 판매자 식별값과 이름을 함께 내려주기 위해 판매자 필드를 추가했다.
     private Long sellerId;         // 판매자 ID
@@ -33,7 +35,9 @@ public class ProductDto {
                 .isSoldOut(product.getIsSoldOut())
                 .quantity(product.getQuantity())
                 .salesCount(product.getSalesCount())
-                .mainImage(product.getDescription())
+                // 상품 설명과 이미지 URL을 각각 다른 응답 필드로 내려주게 수정함
+                .description(product.getDescription())
+                .mainImage(product.getMainImage())
                 // 상품 응답의 판매자 식별값을 내부 PK로 맞춰 다른 도메인과 같은 사용자 키를 쓰게 수정함
                 .sellerId(product.getSeller() != null ? product.getSeller().getId() : null)
                 .sellerName(product.getSeller() != null ? product.getSeller().getUserName() : null)
@@ -49,7 +53,9 @@ public class ProductDto {
                 .isSoldOut(dto.getIsSoldOut())
                 .quantity(dto.getQuantity())
                 .salesCount(dto.getSalesCount())
-                .description(dto.getMainImage())
+                // 상품 설명과 이미지 URL을 엔티티의 분리된 컬럼에 각각 저장함
+                .description(dto.getDescription())
+                .mainImage(dto.getMainImage())
                 .build();
     }
 }

--- a/src/main/java/com/project/marketplace/product/entity/Product.java
+++ b/src/main/java/com/project/marketplace/product/entity/Product.java
@@ -40,6 +40,9 @@ public class Product {
 
     private String description;
 
+    // 상품 설명과 이미지 저장 위치를 분리해 S3/CloudFront 이미지 URL을 별도 보관함
+    private String mainImage;
+
     // 품절 여부
     @Column(nullable = false)
     private Boolean isSoldOut;

--- a/src/main/java/com/project/marketplace/product/service/ProductService.java
+++ b/src/main/java/com/project/marketplace/product/service/ProductService.java
@@ -101,7 +101,9 @@ public class ProductService {
         product.setCategory(dto.getCategory());
         product.setPrice(dto.getPrice());
         product.setQuantity(dto.getQuantity());
-        product.setDescription(dto.getMainImage());
+        // 상품 수정 시 설명과 이미지 URL이 서로 덮어쓰지 않도록 분리된 필드를 반영함
+        product.setDescription(dto.getDescription());
+        product.setMainImage(dto.getMainImage());
         product.setIsSoldOut(dto.getQuantity() <= 0);
         // 수정 요청의 sellerId는 상품 소유자 변경으로 악용될 수 있어 반영하지 않음
 

--- a/src/main/java/com/project/marketplace/product/service/ProductService.java
+++ b/src/main/java/com/project/marketplace/product/service/ProductService.java
@@ -3,6 +3,8 @@ package com.project.marketplace.product.service;
 import com.project.marketplace.product.dto.ProductDto;
 import com.project.marketplace.product.entity.Product;
 import com.project.marketplace.product.repository.ProductRepository;
+import com.project.marketplace.storage.ImageStorageService;
+import com.project.marketplace.storage.ImageUploadType;
 import com.project.marketplace.user.entity.User;
 import com.project.marketplace.user.entity.UserRole;
 import com.project.marketplace.user.repository.UserRepository;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
@@ -25,6 +28,7 @@ public class ProductService {
 
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
+    private final ImageStorageService imageStorageService;
 
     @Transactional(readOnly = true)
     public List<ProductDto> getAllProducts() {
@@ -88,6 +92,13 @@ public class ProductService {
     }
 
     @Transactional
+    public Long createProduct(ProductDto dto, MultipartFile mainImageFile) {
+        // 이미지 파일이 포함된 상품 등록은 S3 업로드 결과 URL을 mainImage에 넣고 기존 저장 흐름을 재사용함
+        applyMainImage(dto, mainImageFile);
+        return createProduct(dto);
+    }
+
+    @Transactional
     public void updateProduct(ProductDto dto, Long requesterUserId) {
         Product product = productRepository.findById(dto.getProductId())
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "상품을 찾을 수 없습니다."));
@@ -108,6 +119,13 @@ public class ProductService {
         // 수정 요청의 sellerId는 상품 소유자 변경으로 악용될 수 있어 반영하지 않음
 
         productRepository.save(product);
+    }
+
+    @Transactional
+    public void updateProduct(ProductDto dto, Long requesterUserId, MultipartFile mainImageFile) {
+        // 이미지 파일이 포함된 상품 수정은 업로드된 URL만 교체하고 권한 검증은 기존 수정 흐름을 재사용함
+        applyMainImage(dto, mainImageFile);
+        updateProduct(dto, requesterUserId);
     }
 
     @Transactional
@@ -162,6 +180,15 @@ public class ProductService {
         if (!canManage) {
             throw new ResponseStatusException(FORBIDDEN, forbiddenMessage);
         }
+    }
+
+    private void applyMainImage(ProductDto dto, MultipartFile mainImageFile) {
+        // 빈 파일 요청은 기존 이미지 값을 유지하고 실제 파일이 있을 때만 S3 업로드를 수행함
+        if (mainImageFile == null || mainImageFile.isEmpty()) {
+            return;
+        }
+
+        dto.setMainImage(imageStorageService.upload(mainImageFile, ImageUploadType.PRODUCT));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/project/marketplace/storage/ImageStorageException.java
+++ b/src/main/java/com/project/marketplace/storage/ImageStorageException.java
@@ -1,0 +1,23 @@
+package com.project.marketplace.storage;
+
+import org.springframework.http.HttpStatus;
+
+public class ImageStorageException extends RuntimeException {
+
+    // 저장소 실패 원인에 따라 API 응답 상태를 다르게 내려주기 위해 상태값을 함께 보관함
+    private final HttpStatus status;
+
+    public ImageStorageException(HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public ImageStorageException(HttpStatus status, String message, Throwable cause) {
+        super(message, cause);
+        this.status = status;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/project/marketplace/storage/ImageStorageService.java
+++ b/src/main/java/com/project/marketplace/storage/ImageStorageService.java
@@ -1,0 +1,9 @@
+package com.project.marketplace.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageStorageService {
+
+    // 컨트롤러가 S3 구현 세부사항 없이 이미지 저장 결과 URL만 받게 함
+    String upload(MultipartFile file, ImageUploadType uploadType);
+}

--- a/src/main/java/com/project/marketplace/storage/ImageUploadType.java
+++ b/src/main/java/com/project/marketplace/storage/ImageUploadType.java
@@ -1,0 +1,7 @@
+package com.project.marketplace.storage;
+
+public enum ImageUploadType {
+    // 상품 이미지와 홈 배너 이미지의 S3 prefix를 분리하기 위한 업로드 유형임
+    PRODUCT,
+    BANNER
+}

--- a/src/main/java/com/project/marketplace/storage/S3ImageStorageService.java
+++ b/src/main/java/com/project/marketplace/storage/S3ImageStorageService.java
@@ -1,0 +1,93 @@
+package com.project.marketplace.storage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3ImageStorageService implements ImageStorageService {
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+
+    private final S3Client s3Client;
+    private final StorageProperties storageProperties;
+
+    @Override
+    public String upload(MultipartFile file, ImageUploadType uploadType) {
+        validateFile(file);
+
+        String objectKey = buildObjectKey(file, uploadType);
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(storageProperties.getS3().getBucket())
+                .key(objectKey)
+                .contentType(file.getContentType())
+                .contentLength(file.getSize())
+                .build();
+
+        try {
+            // S3에는 원본 파일 bytes를 저장하고 응답에는 CloudFront 기준 공개 URL만 반환함
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (IOException e) {
+            throw new UncheckedIOException("이미지 파일을 읽지 못했습니다.", e);
+        }
+
+        return storageProperties.buildPublicUrl(objectKey);
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 이미지 파일이 없습니다.");
+        }
+
+        if (storageProperties.getS3().getBucket() == null || storageProperties.getS3().getBucket().isBlank()) {
+            throw new IllegalStateException("S3 버킷 설정이 필요합니다.");
+        }
+
+        long maxUploadSize = storageProperties.getS3().getMaxUploadSizeMb() * 1024L * 1024L;
+        if (file.getSize() > maxUploadSize) {
+            throw new IllegalArgumentException("이미지 파일 크기가 제한을 초과했습니다.");
+        }
+
+        String extension = getExtension(file.getOriginalFilename());
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new IllegalArgumentException("지원하지 않는 이미지 확장자입니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.toLowerCase().startsWith("image/")) {
+            throw new IllegalArgumentException("이미지 파일만 업로드할 수 있습니다.");
+        }
+    }
+
+    private String buildObjectKey(MultipartFile file, ImageUploadType uploadType) {
+        String prefix = storageProperties.getPrefix(uploadType);
+        String extension = getExtension(file.getOriginalFilename());
+        String filename = UUID.randomUUID() + "." + extension;
+
+        if (prefix.isBlank()) {
+            return filename;
+        }
+
+        return prefix + "/" + filename;
+    }
+
+    private String getExtension(String filename) {
+        String cleanFilename = StringUtils.cleanPath(filename == null ? "" : filename);
+        int extensionIndex = cleanFilename.lastIndexOf('.');
+        if (extensionIndex < 0 || extensionIndex == cleanFilename.length() - 1) {
+            return "";
+        }
+
+        return cleanFilename.substring(extensionIndex + 1).toLowerCase();
+    }
+}

--- a/src/main/java/com/project/marketplace/storage/S3ImageStorageService.java
+++ b/src/main/java/com/project/marketplace/storage/S3ImageStorageService.java
@@ -1,15 +1,17 @@
 package com.project.marketplace.storage;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Set;
 import java.util.UUID;
 
@@ -38,7 +40,9 @@ public class S3ImageStorageService implements ImageStorageService {
             // S3에는 원본 파일 bytes를 저장하고 응답에는 CloudFront 기준 공개 URL만 반환함
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
         } catch (IOException e) {
-            throw new UncheckedIOException("이미지 파일을 읽지 못했습니다.", e);
+            throw new ImageStorageException(HttpStatus.BAD_REQUEST, "이미지 파일을 읽지 못했습니다.", e);
+        } catch (S3Exception | SdkClientException e) {
+            throw new ImageStorageException(HttpStatus.SERVICE_UNAVAILABLE, "이미지 저장소에 업로드하지 못했습니다.", e);
         }
 
         return storageProperties.buildPublicUrl(objectKey);
@@ -50,7 +54,7 @@ public class S3ImageStorageService implements ImageStorageService {
         }
 
         if (storageProperties.getS3().getBucket() == null || storageProperties.getS3().getBucket().isBlank()) {
-            throw new IllegalStateException("S3 버킷 설정이 필요합니다.");
+            throw new ImageStorageException(HttpStatus.SERVICE_UNAVAILABLE, "S3 버킷 설정이 필요합니다.");
         }
 
         long maxUploadSize = storageProperties.getS3().getMaxUploadSizeMb() * 1024L * 1024L;

--- a/src/main/java/com/project/marketplace/storage/StorageProperties.java
+++ b/src/main/java/com/project/marketplace/storage/StorageProperties.java
@@ -1,0 +1,119 @@
+package com.project.marketplace.storage;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.storage")
+public class StorageProperties {
+
+    // CloudFront 주소가 비어 있으면 테스트와 로컬에서 object key만 반환하게 둠
+    private String cloudFrontBaseUrl = "";
+
+    // S3 관련 설정을 app.storage.s3 하위로 묶어 환경변수 매핑을 단순화함
+    private final S3 s3 = new S3();
+
+    public String getCloudFrontBaseUrl() {
+        return cloudFrontBaseUrl;
+    }
+
+    public void setCloudFrontBaseUrl(String cloudFrontBaseUrl) {
+        this.cloudFrontBaseUrl = trimTrailingSlash(cloudFrontBaseUrl);
+    }
+
+    public S3 getS3() {
+        return s3;
+    }
+
+    public String getPrefix(ImageUploadType uploadType) {
+        if (uploadType == ImageUploadType.BANNER) {
+            return trimSlashes(s3.bannerPrefix);
+        }
+
+        return trimSlashes(s3.productPrefix);
+    }
+
+    public String buildPublicUrl(String objectKey) {
+        String normalizedKey = trimLeadingSlash(objectKey);
+        if (cloudFrontBaseUrl == null || cloudFrontBaseUrl.isBlank()) {
+            return normalizedKey;
+        }
+
+        return cloudFrontBaseUrl + "/" + normalizedKey;
+    }
+
+    private String trimTrailingSlash(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.replaceAll("/+$", "");
+    }
+
+    private String trimLeadingSlash(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.replaceAll("^/+", "");
+    }
+
+    private String trimSlashes(String value) {
+        return trimTrailingSlash(trimLeadingSlash(value));
+    }
+
+    public static class S3 {
+
+        // AWS SDK 클라이언트가 리전을 항상 갖도록 서울 리전을 기본값으로 둠
+        private String region = "ap-northeast-2";
+
+        // 운영 배포에서만 실제 버킷명을 주입하고 테스트에서는 빈 값으로 둘 수 있게 함
+        private String bucket = "";
+
+        // 상품 이미지와 홈 배너 이미지를 서로 다른 prefix로 분리함
+        private String productPrefix = "products";
+
+        private String bannerPrefix = "home";
+
+        // 과도한 이미지 업로드를 막기 위한 기본 제한값을 설정함
+        private int maxUploadSizeMb = 5;
+
+        public String getRegion() {
+            return region;
+        }
+
+        public void setRegion(String region) {
+            this.region = region;
+        }
+
+        public String getBucket() {
+            return bucket;
+        }
+
+        public void setBucket(String bucket) {
+            this.bucket = bucket;
+        }
+
+        public String getProductPrefix() {
+            return productPrefix;
+        }
+
+        public void setProductPrefix(String productPrefix) {
+            this.productPrefix = productPrefix;
+        }
+
+        public String getBannerPrefix() {
+            return bannerPrefix;
+        }
+
+        public void setBannerPrefix(String bannerPrefix) {
+            this.bannerPrefix = bannerPrefix;
+        }
+
+        public int getMaxUploadSizeMb() {
+            return maxUploadSizeMb;
+        }
+
+        public void setMaxUploadSizeMb(int maxUploadSizeMb) {
+            this.maxUploadSizeMb = maxUploadSizeMb;
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -84,6 +84,20 @@ spring:
 app:
   # OAuth 성공/실패 후 같은 EC2 nginx 도메인의 React 화면으로 이동하게 환경변수로 분리함
   frontend-url: ${FRONTEND_URL:https://hmadeshop.com}
+  storage:
+    # S3 원본 대신 CloudFront 배포 주소를 응답 URL 기준으로 사용함
+    cloud-front-base-url: ${CLOUDFRONT_BASE_URL:}
+    s3:
+      # 운영 버킷 리전을 환경변수로 분리해 S3 클라이언트 설정과 맞춤
+      region: ${AWS_REGION:ap-northeast-2}
+      # 상품/배너 이미지를 저장할 S3 버킷 이름을 운영 환경변수로 주입함
+      bucket: ${AWS_S3_BUCKET:}
+      # 상품 이미지 object key를 한 경로 아래에 모아 관리함
+      product-prefix: ${AWS_S3_PRODUCT_PREFIX:products}
+      # 홈 배너 이미지 object key를 한 경로 아래에 모아 관리함
+      banner-prefix: ${AWS_S3_BANNER_PREFIX:home}
+      # 이미지 업로드 최대 크기를 운영에서 조정할 수 있게 함
+      max-upload-size-mb: ${IMAGE_MAX_UPLOAD_SIZE_MB:5}
   cors:
     # 로컬 Vite 개발 서버와 운영 단일 도메인 React에서 API 호출을 허용함
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,https://hmadeshop.com}

--- a/src/main/resources/templates/product-form.html
+++ b/src/main/resources/templates/product-form.html
@@ -776,6 +776,22 @@
         feedback.className = 'feedback';
     }
 
+
+    async function resolveErrorMessage(response, fallbackMessage) {
+        const errorText = await response.text();
+        if (!errorText) {
+            return fallbackMessage;
+        }
+
+        try {
+            // 백엔드 공통 ErrorResponse의 message만 화면에 보여 JSON 원문 노출을 막음
+            const errorBody = JSON.parse(errorText);
+            return errorBody.message || fallbackMessage;
+        } catch (error) {
+            return errorText;
+        }
+    }
+
     // 등록 완료 뒤 입력 폼과 JSON 미리보기를 초기 상태로 되돌리게 초기화 함수를 추가
     function resetProductForm() {
         form.reset();
@@ -882,8 +898,8 @@
         try {
             const response = await fetch('/api/products/mine');
             if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(errorText || '등록 상품 목록을 불러오지 못했습니다.');
+                // 공통 에러 응답에서 message를 추출해 목록 조회 실패 사유를 간단히 표시함
+                throw new Error(await resolveErrorMessage(response, '등록 상품 목록을 불러오지 못했습니다.'));
             }
 
             const products = await response.json();
@@ -923,8 +939,8 @@
             });
 
             if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(errorText || '상품 삭제 요청이 실패했습니다.');
+                // 삭제 실패 응답도 message 중심으로 표시해 서버 JSON 구조를 화면에 노출하지 않음
+                throw new Error(await resolveErrorMessage(response, '상품 삭제 요청이 실패했습니다.'));
             }
 
             await loadMyProducts();
@@ -965,8 +981,8 @@
             });
 
             if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(errorText || '상품 등록 요청이 실패했습니다.');
+                // 이미지 업로드 실패 등 공통 에러 응답의 message만 사용자에게 안내함
+                throw new Error(await resolveErrorMessage(response, '상품 등록 요청이 실패했습니다.'));
             }
 
             const data = await response.json();

--- a/src/main/resources/templates/product-form.html
+++ b/src/main/resources/templates/product-form.html
@@ -254,6 +254,22 @@
             line-height: 1.5;
         }
 
+        .image-preview {
+            display: none;
+            overflow: hidden;
+            width: min(240px, 100%);
+            aspect-ratio: 4 / 3;
+            border: 1px solid var(--line);
+            border-radius: 12px;
+            background: #f8fbff;
+        }
+
+        .image-preview img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
         .row {
             display: grid;
             grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -608,6 +624,16 @@
                     <small>상품 이미지 URL은 S3/CloudFront 연동 후 별도 이미지 필드로 저장됩니다.</small>
                 </div>
 
+                <div class="field">
+                    <label for="mainImageFile">상품 이미지</label>
+                    <!-- 상품 등록 시 이미지 파일을 multipart 요청의 mainImageFile part로 함께 전송함 -->
+                    <input id="mainImageFile" name="mainImageFile" type="file" accept="image/png,image/jpeg,image/gif,image/webp">
+                    <small>JPG, PNG, GIF, WebP 이미지를 선택할 수 있습니다.</small>
+                    <div id="image-preview" class="image-preview" aria-live="polite">
+                        <img id="image-preview-img" alt="선택한 상품 이미지 미리보기">
+                    </div>
+                </div>
+
                 <div class="actions">
 
                     <button id="submit-button" class="btn btn-primary" type="submit">상품 등록하기</button>
@@ -657,6 +683,8 @@
     const previewButton = document.getElementById('preview-button');
     const submitButton = document.getElementById('submit-button');
     const feedback = document.getElementById('form-feedback');
+    const imagePreview = document.getElementById('image-preview');
+    const imagePreviewImg = document.getElementById('image-preview-img');
     const myProductsCount = document.getElementById('my-products-count');
     const myProductsList = document.getElementById('my-products-list');
     const myProductsFeedback = document.getElementById('my-products-feedback');
@@ -701,6 +729,42 @@
     }
 
 
+    function getSelectedImageFile() {
+        return form.mainImageFile.files && form.mainImageFile.files.length > 0
+            ? form.mainImageFile.files[0]
+            : null;
+    }
+
+
+    function validateImageFile(file) {
+        if (!file) {
+            return null;
+        }
+
+        if (!file.type || !file.type.startsWith('image/')) {
+            return '이미지 파일만 업로드할 수 있습니다.';
+        }
+
+        if (file.size > 5 * 1024 * 1024) {
+            return '이미지 파일은 5MB 이하로 선택해주세요.';
+        }
+
+        return null;
+    }
+
+
+    function buildProductFormData(payload, imageFile) {
+        const formData = new FormData();
+        // 상품 JSON과 이미지 파일을 같은 multipart 요청으로 보내 백엔드 RequestPart 이름과 맞춤
+        formData.append('product', new Blob([JSON.stringify(payload)], { type: 'application/json' }));
+        if (imageFile) {
+            formData.append('mainImageFile', imageFile);
+        }
+
+        return formData;
+    }
+
+
     function renderFeedback(message, type) {
         feedback.textContent = message;
         feedback.className = `feedback ${type === 'success' ? 'is-success' : 'is-error'}`;
@@ -715,6 +779,8 @@
     // 등록 완료 뒤 입력 폼과 JSON 미리보기를 초기 상태로 되돌리게 초기화 함수를 추가
     function resetProductForm() {
         form.reset();
+        imagePreview.style.display = 'none';
+        imagePreviewImg.removeAttribute('src');
         preview.textContent = JSON.stringify({
             productName: '',
             category: '',
@@ -725,6 +791,20 @@
             sellerId: Number(document.body.dataset.currentUserId || 0)
         }, null, 2);
     }
+
+
+    form.mainImageFile.addEventListener('change', () => {
+        const imageFile = getSelectedImageFile();
+        if (!imageFile) {
+            imagePreview.style.display = 'none';
+            imagePreviewImg.removeAttribute('src');
+            return;
+        }
+
+        // 선택한 이미지를 업로드 전에 미리 보여줘 잘못 고른 파일을 바로 확인하게 함
+        imagePreviewImg.src = URL.createObjectURL(imageFile);
+        imagePreview.style.display = 'block';
+    });
 
 
     function escapeHtml(value) {
@@ -860,10 +940,16 @@
     form.addEventListener('submit', async () => {
         const payload = buildPayload();
         const validationMessage = validatePayload(payload);
+        const imageFile = getSelectedImageFile();
+        const imageValidationMessage = validateImageFile(imageFile);
         preview.textContent = JSON.stringify(payload, null, 2);
 
         if (validationMessage) {
             renderFeedback(validationMessage, 'error');
+            return;
+        }
+        if (imageValidationMessage) {
+            renderFeedback(imageValidationMessage, 'error');
             return;
         }
 
@@ -872,12 +958,10 @@
         submitButton.textContent = '등록 중...';
 
         try {
+            const requestBody = buildProductFormData(payload, imageFile);
             const response = await fetch('/api/products', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(payload)
+                body: requestBody
             });
 
             if (!response.ok) {

--- a/src/main/resources/templates/product-form.html
+++ b/src/main/resources/templates/product-form.html
@@ -602,9 +602,10 @@
                 </div>
 
                 <div class="field">
-                    <label for="mainImage">상품 설명</label>
-                    <textarea id="mainImage" name="mainImage" placeholder="예: 제작 방식, 재질, 크기, 주의사항 등을 적어주세요."></textarea>
-                    <small>현재 DTO에서는 이 필드가 `mainImage` 이름이지만 실제로는 설명 문자열로 저장되고 있습니다.</small>
+                    <label for="description">상품 설명</label>
+                    <!-- 상품 설명을 이미지 경로와 분리된 description 필드로 전송하게 수정함 -->
+                    <textarea id="description" name="description" placeholder="예: 제작 방식, 재질, 크기, 주의사항 등을 적어주세요."></textarea>
+                    <small>상품 이미지 URL은 S3/CloudFront 연동 후 별도 이미지 필드로 저장됩니다.</small>
                 </div>
 
                 <div class="actions">
@@ -620,6 +621,7 @@
   "category": "",
   "price": 0,
   "quantity": 0,
+  "description": "",
   "mainImage": "",
   "sellerId": 0
 }</pre>
@@ -668,7 +670,9 @@
             category: form.category.value,
             price: Number(form.price.value || 0),
             quantity: Number(form.quantity.value || 0),
-            mainImage: form.mainImage.value.trim(),
+            // 상품 설명과 이미지 경로를 분리해 API payload를 구성함
+            description: form.description.value.trim(),
+            mainImage: '',
             sellerId: currentUserId
         };
     }
@@ -690,7 +694,7 @@
         if (!Number.isFinite(payload.quantity) || payload.quantity < 0) {
             return '재고 수량은 0 이상으로 입력해주세요.';
         }
-        if (!payload.mainImage) {
+        if (!payload.description) {
             return '상품 설명을 입력해주세요.';
         }
         return null;
@@ -716,6 +720,7 @@
             category: '',
             price: 0,
             quantity: 0,
+            description: '',
             mainImage: '',
             sellerId: Number(document.body.dataset.currentUserId || 0)
         }, null, 2);

--- a/src/test/java/com/project/marketplace/product/dto/ProductDtoTest.java
+++ b/src/test/java/com/project/marketplace/product/dto/ProductDtoTest.java
@@ -1,0 +1,58 @@
+package com.project.marketplace.product.dto;
+
+import com.project.marketplace.product.entity.Product;
+import com.project.marketplace.user.entity.User;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductDtoTest {
+
+    @Test
+    void fromEntitySeparatesDescriptionAndMainImage() {
+        Product product = Product.builder()
+                .id(1L)
+                .name("수제 머그컵")
+                .category("주방")
+                .price(12000)
+                .isSoldOut(false)
+                .quantity(5)
+                .salesCount(2)
+                // 상품 설명과 이미지 URL이 응답에서 서로 덮어쓰지 않도록 분리 매핑을 검증함
+                .description("손으로 빚은 도자기 머그컵")
+                .mainImage("https://cdn.example.com/products/1/main.jpg")
+                .seller(User.builder()
+                        .id(3L)
+                        .userName("도자기 공방")
+                        .build())
+                .build();
+
+        ProductDto dto = ProductDto.fromEntity(product);
+
+        assertThat(dto.getDescription()).isEqualTo("손으로 빚은 도자기 머그컵");
+        assertThat(dto.getMainImage()).isEqualTo("https://cdn.example.com/products/1/main.jpg");
+        assertThat(dto.getSellerId()).isEqualTo(3L);
+        assertThat(dto.getSellerName()).isEqualTo("도자기 공방");
+    }
+
+    @Test
+    void toEntitySeparatesDescriptionAndMainImage() {
+        ProductDto dto = ProductDto.builder()
+                .productId(1L)
+                .productName("수제 머그컵")
+                .category("주방")
+                .price(12000)
+                .isSoldOut(false)
+                .quantity(5)
+                .salesCount(2)
+                // 상품 저장 시 설명과 이미지 URL이 분리된 엔티티 필드로 들어가는지 검증함
+                .description("손으로 빚은 도자기 머그컵")
+                .mainImage("https://cdn.example.com/products/1/main.jpg")
+                .build();
+
+        Product product = ProductDto.toEntity(dto);
+
+        assertThat(product.getDescription()).isEqualTo("손으로 빚은 도자기 머그컵");
+        assertThat(product.getMainImage()).isEqualTo("https://cdn.example.com/products/1/main.jpg");
+    }
+}

--- a/src/test/java/com/project/marketplace/product/service/ProductServiceTest.java
+++ b/src/test/java/com/project/marketplace/product/service/ProductServiceTest.java
@@ -1,0 +1,64 @@
+package com.project.marketplace.product.service;
+
+import com.project.marketplace.product.dto.ProductDto;
+import com.project.marketplace.product.entity.Product;
+import com.project.marketplace.product.repository.ProductRepository;
+import com.project.marketplace.storage.ImageStorageService;
+import com.project.marketplace.storage.ImageUploadType;
+import com.project.marketplace.user.entity.User;
+import com.project.marketplace.user.entity.UserRole;
+import com.project.marketplace.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProductServiceTest {
+
+    @Test
+    void createProductWithImageStoresUploadedImageUrl() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        ImageStorageService imageStorageService = mock(ImageStorageService.class);
+        ProductService productService = new ProductService(productRepository, userRepository, imageStorageService);
+        User seller = User.builder()
+                .id(7L)
+                .role(UserRole.SELLER)
+                .userName("판매자")
+                .provider("local")
+                .build();
+        ProductDto dto = ProductDto.builder()
+                .productName("수제 컵")
+                .category("주방")
+                .price(12000)
+                .quantity(3)
+                .description("핸드메이드 컵")
+                .sellerId(7L)
+                .build();
+        MockMultipartFile imageFile = new MockMultipartFile("mainImageFile", "cup.jpg", "image/jpeg", "image".getBytes());
+        when(userRepository.findById(7L)).thenReturn(Optional.of(seller));
+        when(imageStorageService.upload(imageFile, ImageUploadType.PRODUCT))
+                .thenReturn("https://cdn.example.com/products/cup.jpg");
+        when(productRepository.save(any(Product.class))).thenAnswer(invocation -> {
+            Product product = invocation.getArgument(0);
+            product.setId(10L);
+            return product;
+        });
+
+        Long productId = productService.createProduct(dto, imageFile);
+
+        ArgumentCaptor<Product> productCaptor = ArgumentCaptor.forClass(Product.class);
+        verify(productRepository).save(productCaptor.capture());
+        // 이미지 파일이 있을 때 업로드 URL이 mainImage로 저장되는지 검증함
+        assertThat(productCaptor.getValue().getMainImage()).isEqualTo("https://cdn.example.com/products/cup.jpg");
+        assertThat(productCaptor.getValue().getDescription()).isEqualTo("핸드메이드 컵");
+        assertThat(productId).isEqualTo(10L);
+    }
+}

--- a/src/test/java/com/project/marketplace/storage/S3ImageStorageServiceTest.java
+++ b/src/test/java/com/project/marketplace/storage/S3ImageStorageServiceTest.java
@@ -1,0 +1,43 @@
+package com.project.marketplace.storage;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockMultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class S3ImageStorageServiceTest {
+
+    @Test
+    void uploadStoresImageWithProductPrefixAndReturnsCloudFrontUrl() {
+        S3Client s3Client = mock(S3Client.class);
+        StorageProperties storageProperties = new StorageProperties();
+        storageProperties.setCloudFrontBaseUrl("https://cdn.example.com");
+        storageProperties.getS3().setBucket("handmade-images");
+        storageProperties.getS3().setProductPrefix("products");
+        S3ImageStorageService storageService = new S3ImageStorageService(s3Client, storageProperties);
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "main.jpg",
+                "image/jpeg",
+                "image".getBytes()
+        );
+
+        String imageUrl = storageService.upload(file, ImageUploadType.PRODUCT);
+
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(requestCaptor.capture(), any(RequestBody.class));
+        PutObjectRequest request = requestCaptor.getValue();
+
+        assertThat(request.bucket()).isEqualTo("handmade-images");
+        assertThat(request.key()).startsWith("products/").endsWith(".jpg");
+        assertThat(request.contentType()).isEqualTo("image/jpeg");
+        assertThat(imageUrl).startsWith("https://cdn.example.com/products/").endsWith(".jpg");
+    }
+}

--- a/src/test/java/com/project/marketplace/storage/S3ImageStorageServiceTest.java
+++ b/src/test/java/com/project/marketplace/storage/S3ImageStorageServiceTest.java
@@ -2,12 +2,14 @@ package com.project.marketplace.storage;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -39,5 +41,23 @@ class S3ImageStorageServiceTest {
         assertThat(request.key()).startsWith("products/").endsWith(".jpg");
         assertThat(request.contentType()).isEqualTo("image/jpeg");
         assertThat(imageUrl).startsWith("https://cdn.example.com/products/").endsWith(".jpg");
+    }
+
+    @Test
+    void uploadFailsWithServiceUnavailableWhenBucketIsMissing() {
+        S3Client s3Client = mock(S3Client.class);
+        StorageProperties storageProperties = new StorageProperties();
+        S3ImageStorageService storageService = new S3ImageStorageService(s3Client, storageProperties);
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "main.jpg",
+                "image/jpeg",
+                "image".getBytes()
+        );
+
+        assertThatThrownBy(() -> storageService.upload(file, ImageUploadType.PRODUCT))
+                .isInstanceOf(ImageStorageException.class)
+                .extracting("status")
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/src/test/java/com/project/marketplace/storage/StoragePropertiesTest.java
+++ b/src/test/java/com/project/marketplace/storage/StoragePropertiesTest.java
@@ -1,0 +1,29 @@
+package com.project.marketplace.storage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StoragePropertiesTest {
+
+    @Test
+    void buildPublicUrlUsesCloudFrontBaseUrl() {
+        StorageProperties storageProperties = new StorageProperties();
+        storageProperties.setCloudFrontBaseUrl("https://cdn.example.com/");
+
+        String publicUrl = storageProperties.buildPublicUrl("/products/main.jpg");
+
+        assertThat(publicUrl).isEqualTo("https://cdn.example.com/products/main.jpg");
+    }
+
+    @Test
+    void getPrefixSeparatesProductAndBanner() {
+        StorageProperties storageProperties = new StorageProperties();
+        // 상품과 배너 업로드 위치가 서로 섞이지 않도록 prefix 정규화를 검증함
+        storageProperties.getS3().setProductPrefix("/products/");
+        storageProperties.getS3().setBannerPrefix("/home/");
+
+        assertThat(storageProperties.getPrefix(ImageUploadType.PRODUCT)).isEqualTo("products");
+        assertThat(storageProperties.getPrefix(ImageUploadType.BANNER)).isEqualTo("home");
+    }
+}


### PR DESCRIPTION
  작업 내용                                                                                                                       
  - 상품 설명 필드와 대표 이미지 URL 필드 분리                                                                                       
  - S3 이미지 저장 설정 추가                                                                                                         
  - 상품 등록/수정 API에 이미지 multipart 업로드 추가                                                                                
  - 업로드된 이미지의 CloudFront URL을 상품 대표 이미지로 저장                                                                       
  - 상품 등록 화면에서 이미지 파일 선택/미리보기/업로드 연동                                                                         
  - 홈 배너 이미지 CloudFront URL 연동                                                                                               
  - 이미지 업로드 실패 시 사용자에게 에러 메시지 표시 개선                                                                           
                                                                                                                                                                                                                            
                                                                                                                                     
                                                                                                                       

